### PR TITLE
Remove unused tol parameter

### DIFF
--- a/R/vcgDijkstra.r
+++ b/R/vcgDijkstra.r
@@ -3,7 +3,6 @@
 #' Compute geodesic distances on a triangular mesh
 #' @param x triangular mesh of class \code{mesh3d}
 #' @param vertpointer integer: references indices of vertices on the mesh
-#' @param tol numeric: threshold for max distances to consider
 #' @return returns a vector of shortest distances for each of the vertices to one of the vertices referenced in \code{vertpointer}
 #' @examples
 #' ## Compute geodesic distance between all mesh vertices and the first vertex of a mesh
@@ -17,11 +16,11 @@
 #' }
 #' @note Make sure to have a clean manifold mesh.
 #' @export
-vcgDijkstra <- function(x, vertpointer,tol=1e6) {
+vcgDijkstra <- function(x, vertpointer) {
     vertpointer <- as.integer(vertpointer-1)
     vb <- x$vb
     it <- x$it-1
-    out <- .Call("Rdijkstra",vb,it,vertpointer,tol)
+    out <- .Call("Rdijkstra",vb,it,vertpointer)
     return(out)
 }
 

--- a/R/vcgDijkstra.r
+++ b/R/vcgDijkstra.r
@@ -1,6 +1,5 @@
-#' Compute geodesic distances on a triangular mesh
-#' 
-#' Compute geodesic distances on a triangular mesh
+
+#' @title Compute pseudo-geodesic distances on a triangular mesh
 #' @param x triangular mesh of class \code{mesh3d}
 #' @param vertpointer integer: references indices of vertices on the mesh
 #' @return returns a vector of shortest distances for each of the vertices to one of the vertices referenced in \code{vertpointer}
@@ -14,7 +13,7 @@
 #' meshDist(humface,distvec = geo)
 #' spheres3d(vert2points(humface)[1,],col=2)
 #' }
-#' @note Make sure to have a clean manifold mesh.
+#' @note Make sure to have a clean manifold mesh. Note that this computes the length of the pseudo-geodesic path (following the edges) between the two vertices.
 #' @export
 vcgDijkstra <- function(x, vertpointer) {
     vertpointer <- as.integer(vertpointer-1)
@@ -25,14 +24,12 @@ vcgDijkstra <- function(x, vertpointer) {
 }
 
 
-#' Compute geodesic distance between two points on a mesh
-#'
-#' Compute geodesic distance between two points on a mesh
+#' @title Compute pseudo-geodesic distance between two points on a mesh
 #' @param x triangular mesh of class \code{mesh3d}
 #' @param pt1 3D coordinate on mesh or index of vertex
 #' @param pt2 3D coordinate on mesh or index of vertex
 #' @return returns the geodesic distance between \code{pt1} and \code{pt2}.
-#' @note Make sure to have a clean manifold mesh.
+#' @note Make sure to have a clean manifold mesh. Note that this computes the length of the pseudo-geodesic path (following the edges) between the two vertices closest to these points.
 #' @examples
 #' data(humface)
 #' pt1 <- humface.lm[1,]

--- a/src/Rdijkstra.cpp
+++ b/src/Rdijkstra.cpp
@@ -9,14 +9,13 @@ using namespace Rcpp;
 //using namespace std;
   
   
-RcppExport SEXP Rdijkstra(SEXP vb_, SEXP it_, SEXP verts_, SEXP tol_)
+RcppExport SEXP Rdijkstra(SEXP vb_, SEXP it_, SEXP verts_)
 {
   try {
   // declare Mesh and helper variables
   //int select = Rcpp::as<int>(type_);  
   IntegerVector verts(verts_);
   int n = verts.length();
-  double tol = Rcpp::as<double>(tol_);  
   int i, rem;
   MyMesh m;
   VertexIterator vi;

--- a/src/Rdijkstra.cpp
+++ b/src/Rdijkstra.cpp
@@ -3,57 +3,46 @@
 #include <RcppArmadillo.h>
 #include<vcg/complex/algorithms/geodesic.h>
 
-//using namespace vcg;
 using namespace tri;
 using namespace Rcpp;
-//using namespace std;
-  
-  
+
 RcppExport SEXP Rdijkstra(SEXP vb_, SEXP it_, SEXP verts_)
 {
   try {
-  // declare Mesh and helper variables
-  //int select = Rcpp::as<int>(type_);  
-  IntegerVector verts(verts_);
-  int n = verts.length();
-  int i, rem;
-  MyMesh m;
-  VertexIterator vi;
-  FaceIterator fi;
-  // allocate mesh and fill it
-  Rvcg::IOMesh<MyMesh>::RvcgReadR(m,vb_,it_);
-  m.vert.EnableVFAdjacency();
-  m.vert.EnableQuality();
-  m.face.EnableFFAdjacency();
-  m.face.EnableVFAdjacency();
-  tri::UpdateTopology<MyMesh>::VertexFace(m);
-  std::vector<MyVertex*> seedVec;
-  for (int i=0; i < n; i++) {
-    vi = m.vert.begin()+verts[i];
-    seedVec.push_back(&*vi);
-  }
-  tri::EuclideanDistance<MyMesh> ed;
-  //tri::Clean<MyMesh>::RemoveUnreferencedVertex(m);
-   //tri::Allocator<MyMesh>::CompactEveryVector(m);
-  
-   //tri::Geodesic<MyMesh>::Compute(m,seedVec,ed);
-   tri::Geodesic<MyMesh>::PerVertexDijkstraCompute(m,seedVec,ed);
-   std::vector<float> geodist;
-   vi=m.vert.begin();
-   for (int i=0; i < m.vn; i++) {
-     geodist.push_back(vi->Q());
-     ++vi;
-   }
-  //write back
-   
-     return wrap(geodist);
-  // vcg::tri::Allocator< MyMesh >::CompactVertexVector(m);
-  // vcg::tri::Allocator< MyMesh >::CompactFaceVector(m);
-  // tri::UpdateNormal<MyMesh>::PerVertexAngleWeighted(m);
-  // tri::UpdateNormal<MyMesh>::NormalizePerVertex(m);
-  // List out = Rvcg::IOMesh<MyMesh>::RvcgToR(m,true);
-  // out.attr("class") = "mesh3d";
-  // return out;
+    // Declare Mesh and helper variables
+    IntegerVector verts(verts_);
+    int n = verts.length();
+    int i, rem;
+    MyMesh m;
+    VertexIterator vi;
+    FaceIterator fi;
+    
+    // Allocate mesh and fill it
+    Rvcg::IOMesh<MyMesh>::RvcgReadR(m,vb_,it_);
+    m.vert.EnableVFAdjacency();
+    m.vert.EnableQuality();
+    m.face.EnableFFAdjacency();
+    m.face.EnableVFAdjacency();
+    tri::UpdateTopology<MyMesh>::VertexFace(m);
+    
+    // Prepare seed vector
+    std::vector<MyVertex*> seedVec;
+    for (int i=0; i < n; i++) {
+      vi = m.vert.begin()+verts[i];
+      seedVec.push_back(&*vi);
+    }
+    
+    // Compute pseudo-geodesic distance by summing dists along shortest path in graph.
+    tri::EuclideanDistance<MyMesh> ed;
+    tri::Geodesic<MyMesh>::PerVertexDijkstraCompute(m,seedVec,ed);
+    std::vector<float> geodist;
+    vi=m.vert.begin();
+    for (int i=0; i < m.vn; i++) {
+      geodist.push_back(vi->Q());
+      ++vi;
+    }
+    return wrap(geodist);
+    
   } catch (std::exception& e) {
     ::Rf_error( e.what());
     return wrap(1);
@@ -61,6 +50,3 @@ RcppExport SEXP Rdijkstra(SEXP vb_, SEXP it_, SEXP verts_)
     ::Rf_error("unknown exception");
   }
 }
- 
-
-    

--- a/src/init.c
+++ b/src/init.c
@@ -22,7 +22,7 @@ extern SEXP RclosestKD(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEX
 extern SEXP Rclost(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP RCone(SEXP, SEXP, SEXP, SEXP);
 extern SEXP Rcurvature(SEXP, SEXP);
-extern SEXP Rdijkstra(SEXP, SEXP, SEXP, SEXP);
+extern SEXP Rdijkstra(SEXP, SEXP, SEXP);
 extern SEXP RDodecahedron(SEXP);
 extern SEXP RgetEdge(SEXP, SEXP, SEXP);
 extern SEXP RHexahedron(SEXP);
@@ -70,7 +70,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"Rclost",                        (DL_FUNC) &Rclost,                         8},
     {"RCone",                         (DL_FUNC) &RCone,                          4},
     {"Rcurvature",                    (DL_FUNC) &Rcurvature,                     2},
-    {"Rdijkstra",                     (DL_FUNC) &Rdijkstra,                      4},
+    {"Rdijkstra",                     (DL_FUNC) &Rdijkstra,                      3},
     {"RDodecahedron",                 (DL_FUNC) &RDodecahedron,                  1},
     {"RgetEdge",                      (DL_FUNC) &RgetEdge,                       3},
     {"RHexahedron",                   (DL_FUNC) &RHexahedron,                    1},


### PR DESCRIPTION
This PR:

* removes the unused `_tol` parameter for the `vcgDijkstra` function and
* makes it clear in the docs the pseudo-geodesic dist is computed.
* reformats and cleans up the code a bit.

It's easiest to see what is being done by looking at the commits separately, as the third makes it hard to tell what has been done when looking at the combined changes.

One could alternatively implement the parameter, but given the speed of the current solution, I guess that it's not really needed for most meshes (and filtering afterwards can be done in R anyways).