### PR TITLE
Add maxdist parameter to vcgDijkstra

### DIFF
--- a/R/vcgDijkstra.r
+++ b/R/vcgDijkstra.r
@@ -1,8 +1,9 @@
 
 #' @title Compute pseudo-geodesic distances on a triangular mesh
 #' @param x triangular mesh of class \code{mesh3d}
-#' @param vertpointer integer: references indices of vertices on the mesh
-#' @return returns a vector of shortest distances for each of the vertices to one of the vertices referenced in \code{vertpointer}
+#' @param vertpointer integer: references indices of vertices on the mesh, typically only a single query vertex.
+#' @param maxdist positive scalar double, the maximal distance to travel along the mesh when computing distances. Leave at \code{NULL} to traverse the full mesh. This can be used to speed up the computation if you are only interested in geodesic distances to neighbors within a limited distance around the query vertices.
+#' @return returns a vector of shortest distances for each of the vertices to one of the vertices referenced in \code{vertpointer}. If \code{maxdis}t is in use (not \code{NULL}), the distance values for vertices outside the requested \code{maxdist} are not computed and appear as \code{0}.
 #' @examples
 #' ## Compute geodesic distance between all mesh vertices and the first vertex of a mesh
 #' data(humface)
@@ -15,11 +16,17 @@
 #' }
 #' @note Make sure to have a clean manifold mesh. Note that this computes the length of the pseudo-geodesic path (following the edges) between the two vertices.
 #' @export
-vcgDijkstra <- function(x, vertpointer) {
+vcgDijkstra <- function(x, vertpointer, maxdist=NULL) {
     vertpointer <- as.integer(vertpointer-1)
     vb <- x$vb
     it <- x$it-1
-    out <- .Call("Rdijkstra",vb,it,vertpointer)
+    if(is.null(maxdist)) {
+      maxdist = -1.0;
+    }
+    if(! (is.numeric(maxdist) && length(maxdist) == 1L)) {
+      stop("Parameter 'maxdist' must be NULL or a scalar double value.");
+    }
+    out <- .Call("Rdijkstra",vb,it,vertpointer, as.double(maxdist));
     return(out)
 }
 

--- a/man/vcgDijkstra.Rd
+++ b/man/vcgDijkstra.Rd
@@ -4,15 +4,17 @@
 \alias{vcgDijkstra}
 \title{Compute pseudo-geodesic distances on a triangular mesh}
 \usage{
-vcgDijkstra(x, vertpointer)
+vcgDijkstra(x, vertpointer, maxdist = NULL)
 }
 \arguments{
 \item{x}{triangular mesh of class \code{mesh3d}}
 
-\item{vertpointer}{integer: references indices of vertices on the mesh}
+\item{vertpointer}{integer: references indices of vertices on the mesh, typically only a single query vertex.}
+
+\item{maxdist}{positive scalar double, the maximal distance to travel along the mesh when computing distances. Leave at \code{NULL} to traverse the full mesh. This can be used to speed up the computation if you are only interested in geodesic distances to neighbors within a limited distance around the query vertices.}
 }
 \value{
-returns a vector of shortest distances for each of the vertices to one of the vertices referenced in \code{vertpointer}
+returns a vector of shortest distances for each of the vertices to one of the vertices referenced in \code{vertpointer}. If \code{maxdis}t is in use (not \code{NULL}), the distance values for vertices outside the requested \code{maxdist} are not computed and appear as \code{0}.
 }
 \description{
 Compute pseudo-geodesic distances on a triangular mesh

--- a/src/Rdijkstra.cpp
+++ b/src/Rdijkstra.cpp
@@ -6,11 +6,14 @@
 using namespace tri;
 using namespace Rcpp;
 
-RcppExport SEXP Rdijkstra(SEXP vb_, SEXP it_, SEXP verts_)
+// Compute pseudo-geodesic distance from query verts_ to all others (or to those
+// within a maximal distance of maxdist_ if it is > 0).
+RcppExport SEXP Rdijkstra(SEXP vb_, SEXP it_, SEXP verts_, SEXP maxdist_)
 {
   try {
     // Declare Mesh and helper variables
     IntegerVector verts(verts_);
+    float maxdist = Rcpp::as<float>(maxdist_);
     int n = verts.length();
     int i, rem;
     MyMesh m;
@@ -34,7 +37,12 @@ RcppExport SEXP Rdijkstra(SEXP vb_, SEXP it_, SEXP verts_)
 
     // Compute pseudo-geodesic distance by summing dists along shortest path in graph.
     tri::EuclideanDistance<MyMesh> ed;
-    tri::Geodesic<MyMesh>::PerVertexDijkstraCompute(m,seedVec,ed);
+    if(maxdist > 0.0) {
+      tri::Geodesic<MyMesh>::PerVertexDijkstraCompute(m,seedVec,ed,maxdist);
+    } else {
+      tri::Geodesic<MyMesh>::PerVertexDijkstraCompute(m,seedVec,ed);
+    }
+
     std::vector<float> geodist;
     vi=m.vert.begin();
     for (int i=0; i < m.vn; i++) {

--- a/src/init.c
+++ b/src/init.c
@@ -22,7 +22,7 @@ extern SEXP RclosestKD(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEX
 extern SEXP Rclost(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP RCone(SEXP, SEXP, SEXP, SEXP);
 extern SEXP Rcurvature(SEXP, SEXP);
-extern SEXP Rdijkstra(SEXP, SEXP, SEXP);
+extern SEXP Rdijkstra(SEXP, SEXP, SEXP, SEXP);
 extern SEXP RDodecahedron(SEXP);
 extern SEXP RGeodesicPath(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP RgetEdge(SEXP, SEXP, SEXP);
@@ -74,7 +74,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"Rclost",                        (DL_FUNC) &Rclost,                         8},
     {"RCone",                         (DL_FUNC) &RCone,                          4},
     {"Rcurvature",                    (DL_FUNC) &Rcurvature,                     2},
-    {"Rdijkstra",                     (DL_FUNC) &Rdijkstra,                      3},
+    {"Rdijkstra",                     (DL_FUNC) &Rdijkstra,                      4},
     {"RDodecahedron",                 (DL_FUNC) &RDodecahedron,                  1},
     {"RGeodesicPath",                 (DL_FUNC) &RGeodesicPath,                  5},
     {"RgetEdge",                      (DL_FUNC) &RgetEdge,                       3},


### PR DESCRIPTION
This PR adds the `maxdist` parameter to the `vcgDijkstra` function. It allows early termination, and thus speedup, if one is only interested in the distances in a local neighborhood around each query vertex.

## Background
The computation of geodesic distances on a mesh is a very expensive computation if ones needs the pairwise distances between all vertices. For a mesh of 160k vertices, this requires running `vcgDijkstra` 160k times, which takes several hours on my machine. The introduction of the maxdist parameter allows for a considerable speedup, depending on the requested neighborhood size:

```
library("Rvcg");
library("fsbrain");  # from devtools::install_github("dfsp-spirit/fsbrain", ref="geodesic")
surf = subject.surface(fsaverage.path(T), "fsaverage", hemi="lh", as_tm = TRUE); # load 160k verts brain mesh

# Now compare performance for a single computation over the full mesh versus in a neighborhood of size 50:
microbenchmark::microbenchmark(vcgDijkstra(surf, 1), vcgDijkstra(surf, 1, 50), times=100L);
Unit: milliseconds
                                            expr      min       lq      mean   median       uq      max neval
       vcgDijkstra(surf, 1) 81.11736 85.43365 102.47903 87.97617 94.71902 195.7131  100
 vcgDijkstra(surf, 1, 50) 29.14765 33.18125  44.01884 35.11710 37.59429 120.4902   100
```

Now reduce the requested neighborhood size further to 15 instead of 50:

```
microbenchmark::microbenchmark(vcgDijkstra(surf, 1), vcgDijkstra(surf, 1, 15), times=100L)
Unit: milliseconds
                     expr      min       lq     mean   median       uq       max neval
     vcgDijkstra(surf, 1) 76.89238 79.60710 82.71899 80.49687 84.38636 182.16545   100
 vcgDijkstra(surf, 1, 15) 16.25535 18.88795 20.74153 19.89646 22.24358  30.03371   100
```

Show the distances for the 50 neighborhood:
```
neigh = vcgDijkstra(surf, 1, 50);
neigh[neigh==0.0] = NA;  # cosmetic change for visualization, NA will be rendered as white
vis.data.on.fsaverage(morph_data_lh = neigh, views="si")
```
![dijkstra_maxdist](https://user-images.githubusercontent.com/1061893/124442581-2c5ee880-dd7d-11eb-9930-b5993f84b82e.png)

