### PR TITLE
Fix: include_self parameter in RVVadj function must return 1-based index

### DIFF
--- a/src/RVFadj.cpp
+++ b/src/RVFadj.cpp
@@ -85,7 +85,7 @@ RcppExport SEXP RVVadj(SEXP vb_, SEXP it_, SEXP query_vertices_, SEXP numstep_, 
     // Collect indices of vertices.
     std::vector<int> neighidx;
     if(include_self) {
-      neighidx.push_back(qv);
+      neighidx.push_back(qv + 1); // return 1-based R indices.
     }
     for(int j=0; j<neigh.size(); j++) {
       neighidx.push_back(indices[neigh[j]] + 1); // return 1-based R indices.


### PR DESCRIPTION
I noticed a bug I introduced in the `RVVadj` function: it returns 1-based R indices in general (which is correct), but if the `include_self` parameter was set to TRUE, it added that `self` as a 0-based index. This is fixed in this PR.

Btw, I found this through a unit test in my fsbrain package that uses that Rvcg function. I would feel better if I could add some unit tests to the functions I submitted to Rvcg. What do you think about adding tests, but skipping all of them on CRAN?