### PR TITLE
Documentation fix and fix for crash on repeated calls

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,4 +39,4 @@ LazyLoad: yes
 Biarch: yes
 URL: https://github.com/zarquon42b/Rvcg, https://github.com/cnr-isti-vclab/vcglib
 Encoding: UTF-8
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2

--- a/R/vcgSample.r
+++ b/R/vcgSample.r
@@ -3,16 +3,16 @@
 #' Subsamples surface of a triangular mesh and returns a set of points located on that mesh
 #' @param mesh triangular mesh of class 'mesh3d'
 #' @param SampleNum integer: number of sampled points (see \code{details} below)
-#' @param type character: seclect sampling type ("mc"=MonteCarlo Sampling, "pd"=PoissonDisk Sampling,"km"=kmean clustering)
-#' @param MCsamp integer: MonteCarlo sample iterations used in PoissonDisk sampling.
-#' @param geodes logical: maximise geodesic distance between sample points (only for Poisson Disk sampling)
-#' @param strict logical: if \code{type="pd"} and the amount of coordinates exceeds \code{SampleNum},  the resulting coordinates will be subsampled again by kmean clustering to reach the requested number.
+#' @param type character: select sampling type ("mc"=MonteCarlo Sampling, "pd"=PoissonDisk Sampling,"km"=kmean clustering)
+#' @param MCsamp integer: MonteCarlo oversampling factor.
+#' @param geodes logical: maximize geodesic distance between sample points (only for Poisson Disk sampling)
+#' @param strict logical: if \code{type="pd"} and the amount of coordinates exceeds \code{SampleNum},the resulting coordinates will be subsampled again by kmeans clustering to reach the requested number (Euclidean distances used).
 #' @param iter.max integer: maximum iterations to use in k-means clustering.
 #' @param threads integer number of threads to use for k-means clustering
-#' @details Poisson disk subsampling will not generate the exact amount of coordinates specified in \code{SampleNum}, depending on \code{MCsamp} the result will contain more or less coordinates.
+#' @details The Poisson disk method uses MonteCarlo oversampling followed by Poisson disk pruning. The Poisson disk approach will not generate the exact amount of coordinates specified in \code{SampleNum}, depending on \code{MCsamp} the result will contain more or less coordinates.
 #' @return sampled points
 #' @examples
-#' 
+#'
 #' data(humface)
 #' ss <- vcgSample(humface,SampleNum = 500, type="km",threads=1)
 #' \dontrun{
@@ -51,5 +51,6 @@ vcgSample <- function(mesh, SampleNum=100,type=c("km","pd","mc"),MCsamp=20,geode
             if (!noit)
                 tmp <- t(vcgClostKD(tmp, mesh,sign=FALSE,threads=threads)$vb[1:3,])
         }
+        gc()
         return(tmp)
     }

--- a/man/vcgSample.Rd
+++ b/man/vcgSample.Rd
@@ -20,13 +20,13 @@ vcgSample(
 
 \item{SampleNum}{integer: number of sampled points (see \code{details} below)}
 
-\item{type}{character: seclect sampling type ("mc"=MonteCarlo Sampling, "pd"=PoissonDisk Sampling,"km"=kmean clustering)}
+\item{type}{character: select sampling type ("mc"=MonteCarlo Sampling, "pd"=PoissonDisk Sampling,"km"=kmean clustering)}
 
-\item{MCsamp}{integer: MonteCarlo sample iterations used in PoissonDisk sampling.}
+\item{MCsamp}{integer: MonteCarlo oversampling factor.}
 
-\item{geodes}{logical: maximise geodesic distance between sample points (only for Poisson Disk sampling)}
+\item{geodes}{logical: maximize geodesic distance between sample points (only for Poisson Disk sampling)}
 
-\item{strict}{logical: if \code{type="pd"} and the amount of coordinates exceeds \code{SampleNum},  the resulting coordinates will be subsampled again by kmean clustering to reach the requested number.}
+\item{strict}{logical: if \code{type="pd"} and the amount of coordinates exceeds \code{SampleNum},the resulting coordinates will be subsampled again by kmeans clustering to reach the requested number (Euclidean distances used).}
 
 \item{iter.max}{integer: maximum iterations to use in k-means clustering.}
 
@@ -39,7 +39,7 @@ sampled points
 Subsamples surface of a triangular mesh and returns a set of points located on that mesh
 }
 \details{
-Poisson disk subsampling will not generate the exact amount of coordinates specified in \code{SampleNum}, depending on \code{MCsamp} the result will contain more or less coordinates.
+The Poisson disk method uses MonteCarlo oversampling followed by Poisson disk pruning. The Poisson disk approach will not generate the exact amount of coordinates specified in \code{SampleNum}, depending on \code{MCsamp} the result will contain more or less coordinates.
 }
 \examples{
 

--- a/src/Rsample.cpp
+++ b/src/Rsample.cpp
@@ -19,12 +19,12 @@ using namespace std;
 RcppExport SEXP Rsample(SEXP mesh_, SEXP SampleNum_, SEXP type_, SEXP MCsamp_, SEXP geodes_)
 {
   try {// declare Mesh and helper variables
-    int SampleNum = Rcpp::as<int>(SampleNum_);  
-    //double tol = Rcpp::as<double>(tol_);  
-    const int type = Rcpp::as<int>(type_);  
+    int SampleNum = Rcpp::as<int>(SampleNum_);
+    //double tol = Rcpp::as<double>(tol_);
+    const int type = Rcpp::as<int>(type_);
     const int MCsamp = Rcpp::as<int>(MCsamp_);
     const bool geodes = Rcpp::as<bool>(geodes_);
-    
+
     MyMesh m,msamp;
     float radius;
     VertexIterator vi;
@@ -34,15 +34,19 @@ RcppExport SEXP Rsample(SEXP mesh_, SEXP SampleNum_, SEXP type_, SEXP MCsamp_, S
     if (check != 0) {
       return wrap(1);
     } else {
+      if (geodes) {
+        tri::UpdateTopology<MyMesh>::FaceFace(m);
+        tri::UpdateTopology<MyMesh>::VertexFace(m);
+      }
       vector<Point3f> myVec;
       typedef TrivialSampler<MyMesh>  BaseSampler ;
- 
+
       BaseSampler ts2(myVec);
       std::vector<Point3f> MontecarloSamples, poissonsamples;
       BaseSampler mcSampler(MontecarloSamples);
       BaseSampler pdSampler(poissonsamples);
-  
-  
+
+
       if (type == 1) {
 	tri::MontecarloSampling(m,poissonsamples,SampleNum);
       } else { //this is poison disk sampling with more options than the wrapper commented below
@@ -55,24 +59,24 @@ RcppExport SEXP Rsample(SEXP mesh_, SEXP SampleNum_, SEXP type_, SEXP MCsamp_, S
 	pp.geodesicDistanceFlag=geodes;
 	MyMesh MontecarloMesh;
 	SurfaceSampling<MyMesh,BaseSampler>::Montecarlo(m, mcSampler, SampleNum*MCsamp);
-    
+
 	tri::Allocator<MyMesh>::AddVertices(MontecarloMesh,MontecarloSamples.size());
 	for(unsigned int j=0;j < MontecarloSamples.size();++j)
 	  MontecarloMesh.vert[j].P()=MontecarloSamples[j];
-    
+
 	tri::UpdateBounding<MyMesh>::Box(MontecarloMesh);
 	tri::SurfaceSampling<MyMesh,BaseSampler>::PoissonDiskPruning(pdSampler, MontecarloMesh, radius, pp);
       }
       unsigned int outsize = poissonsamples.size();
       Rcpp::NumericMatrix vbout(3,outsize);
-  
+
       for (unsigned int i=0;  i < outsize; i++) {
 	Point3f tmp = poissonsamples[i];
 	vbout(0,i) = tmp[0];
 	vbout(1,i) =  tmp[1];
 	vbout(2,i) =  tmp[2];
       }
-  
+
       return Rcpp::wrap(vbout);
     }
   } catch (std::exception& e) {
@@ -82,6 +86,6 @@ RcppExport SEXP Rsample(SEXP mesh_, SEXP SampleNum_, SEXP type_, SEXP MCsamp_, S
     Rcpp::stop("unknown exception");
   }
 }
- 
 
-    
+
+


### PR DESCRIPTION
I fixed the documentation of the MCsamp argument, which wrongly stated that it specified a number of Monte Carlo iterations, while according to the VCG source code it is the Monte Carlo oversampling factor. I also clarified what exact approach is used, since this is not self-explanatory.

The reason why I stumbled over this was that I experienced crashes (memory leak alike) when repeatedly calling the function with `type="pd"` in a loop. Inserting `gc()` in the R file solved this, but certainly did not fix the root cause.